### PR TITLE
Fix StreamlitInvalidWidthError in dataframe rendering

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -252,21 +252,21 @@ with col[1]:
 with col[2]:
     st.markdown('#### Top States')
 
-    st.dataframe(df_selected_year_sorted,
-                 column_order=("states", "population"),
-                 hide_index=True,
-                 width=None,
-                 column_config={
-                    "states": st.column_config.TextColumn(
-                        "States",
-                    ),
-                    "population": st.column_config.ProgressColumn(
-                        "Population",
-                        format="%f",
-                        min_value=0,
-                        max_value=max(df_selected_year_sorted.population),
-                     )}
-                 )
+    st.dataframe(
+    df_selected_year_sorted,
+    column_order=("states", "population"),
+    hide_index=True,
+    use_container_width=True,
+    column_config={
+        "states": st.column_config.TextColumn("States"),
+        "population": st.column_config.ProgressColumn(
+            "Population",
+            format="%f",
+            min_value=0,
+            max_value=max(df_selected_year_sorted.population),
+        ),
+    },
+)
     
     with st.expander('About', expanded=True):
         st.write('''


### PR DESCRIPTION
Fix StreamlitInvalidWidthError in dataframe rendering

The app was passing `width=None` to `st.dataframe`, which causes a runtime error in newer versions of Streamlit.

Replaced it with `use_container_width=True` to restore compatibility and ensure responsive layout.

Verified that the app now runs successfully after the change.